### PR TITLE
Change error type in 04-test-class

### DIFF
--- a/src/04-test-class/index.test.ts
+++ b/src/04-test-class/index.test.ts
@@ -10,11 +10,11 @@ describe('BankAccount', () => {
     // Write your test here
   });
 
-  test('should throw TransferFailedError error when transferring more than balance', () => {
+  test('should throw InsufficientFundsError error when transferring more than balance', () => {
     // Write your test here
   });
 
-  test('should throw error when transferring to the same account', () => {
+  test('should throw TransferFailedError error when transferring to the same account', () => {
     // Write your test here
   });
 


### PR DESCRIPTION
Test case in 04-test-class/index.test.ts

```js
test('should throw TransferFailedError error when transferring more than balance', () => {
  // Write your test here
});
```

But in method

```js
  public transfer(amount: number, toAccount: BankAccount): this {
    this.withdraw(amount);
    if (this === toAccount) {
      throw new TransferFailedError();
    }
    toAccount.deposit(amount);

    return this;
  }
```

First of all, we call **this.withdraw(amount);**, and because we try to transfer more than balance **InsufficientFundsError** will be thrown.

Maybe

```js
test('should throw TransferFailedError error when transferring more than balance', () => {
  // Write your test here
});

->

test('should throw InsufficientFundsError error when transferring more than balance', () => {
  // Write your test here
});
```

And for the next test case, probably better to clarify the error (TransferFailedError)

```js
test('should throw error when transferring to the same account', () => {
    // Write your test here
});

->

test('should throw TransferFailedError error when transferring to the same account', () => {
    // Write your test here
});
```
